### PR TITLE
feat(l10n): add displaynameOverride hook to MatrixLocalizations

### DIFF
--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -115,6 +115,10 @@ class User extends StrippedStateEvent {
     bool? mxidLocalPartFallback,
     MatrixLocalizations i18n = const MatrixDefaultLocalizations(),
   }) {
+    final override = i18n.displaynameOverride(id);
+    if (override != null) {
+      return override;
+    }
     formatLocalpart ??= room.client.formatLocalpart;
     mxidLocalPartFallback ??= room.client.mxidLocalPartFallback;
     final displayName = this.displayName;

--- a/lib/src/utils/matrix_localizations.dart
+++ b/lib/src/utils/matrix_localizations.dart
@@ -20,6 +20,14 @@ import 'package:matrix/matrix.dart';
 
 abstract class MatrixLocalizations {
   const MatrixLocalizations();
+
+  /// Optionally overrides the displayname of the user with the given [userId]
+  /// wherever the SDK renders it — state event texts ("x joined the chat"),
+  /// sender name prefixes, and hero-based room names. Return null to use the
+  /// profile displayname. Used e.g. to localize the names of well-known bot
+  /// accounts (pangeachat/client#7487).
+  String? displaynameOverride(String userId) => null;
+
   String get emptyChat;
 
   String get invitedUsersOnly;

--- a/test/user_test.dart
+++ b/test/user_test.dart
@@ -126,6 +126,36 @@ void main() async {
         'Unknown user',
       );
     });
+    test('calcDisplayname with displaynameOverride', () async {
+      final bot = User(
+        '@bot:example.com',
+        membership: 'join',
+        displayName: 'Pangea Bot',
+        room: room,
+      );
+      room.setState(bot);
+      const i18n = _OverrideLocalizations();
+      expect(bot.calcDisplayname(i18n: i18n), 'Localized Bot');
+      expect(bot.calcDisplayname(), 'Pangea Bot');
+      expect(user1.calcDisplayname(i18n: i18n), 'Alice M');
+
+      final joinEvent = Event.fromJson(
+        {
+          'content': {'membership': 'join', 'displayname': 'Pangea Bot'},
+          'type': 'm.room.member',
+          'event_id': '\$botjoin:example.com',
+          'room_id': room.id,
+          'sender': '@bot:example.com',
+          'origin_server_ts': 1432735824653,
+          'state_key': '@bot:example.com',
+        },
+        room,
+      );
+      expect(
+        joinEvent.calcLocalizedBodyFallback(i18n),
+        'Localized Bot joined the chat',
+      );
+    });
     test('kick', () async {
       await user1.kick();
     });
@@ -195,4 +225,12 @@ void main() async {
       await client.dispose(closeDatabase: true);
     });
   });
+}
+
+class _OverrideLocalizations extends MatrixDefaultLocalizations {
+  const _OverrideLocalizations();
+
+  @override
+  String? displaynameOverride(String userId) =>
+      userId == '@bot:example.com' ? 'Localized Bot' : null;
 }


### PR DESCRIPTION
### What

Add a `displaynameOverride(userId)` hook to `MatrixLocalizations` so clients can localize specific users' display names in SDK-generated text.

### Why

Addresses pangeachat/client#7487. The client PR (pangeachat/client#8157) localizes the "Pangea Bot" / "Support" display names client-side, but SDK-generated strings — state event texts ("Pangea Bot joined the chat"), `Sender: message` prefixes in `calcLocalizedBodyFallback`, and hero-based room names — resolve names via `User.calcDisplayname(i18n:)` internally, with no client-side interception point.

### How

- `MatrixLocalizations.displaynameOverride(String userId)` — new virtual method, default `null` (no behavior change for existing implementations, including `MatrixDefaultLocalizations`).
- `User.calcDisplayname` returns the override when non-null, before the profile-name/localpart logic. This single point covers sender names, target names in member-event texts, sender prefixes, and DM hero names — every path that threads `i18n` through.

The client's `MatrixLocals` can then override it to return the localized bot/support names (client-side follow-up after this merges and the `matrix` dep is refreshed).

### Testing

- New test: `calcDisplayname with displaynameOverride` in `test/user_test.dart` — covers the override, the null-default fallback, and a membership state event localizing to "Localized Bot joined the chat".
- `dart analyze lib test/user_test.dart`: no issues.
- `dart test test/user_test.dart test/matrix_localizations_test.dart test/event_test.dart test/room_test.dart`: all pass except 5 pre-existing failures (`encrypted attachments`, `downloadAndDecryptAttachment`, `calcEncryptionHealthState`, `pushRuleState`, `setPushRuleState`) which fail identically on unmodified `main` in this environment (flutter_rust_bridge/vodozemac not initialized locally).

### Deploy Notes

None — no-op until a client implements the override.
